### PR TITLE
Add new configuration parameter and implementation of `commissionPaidByQuoted` for Bitflyer.

### DIFF
--- a/config_default.json
+++ b/config_default.json
@@ -56,6 +56,7 @@
       "maxShortPosition": 0,
       "cashMarginType": "Cash",
       "commissionPercent": 0,
+      "commissionPaidByQuoted": true,
       "noTradePeriods": [["04:00", "04:15"]]
     },
     {

--- a/src/Bitflyer/BrokerAdapterImpl.ts
+++ b/src/Bitflyer/BrokerAdapterImpl.ts
@@ -15,7 +15,7 @@ import { getLogger } from '@bitr/logger';
 import * as _ from 'lodash';
 import BrokerApi from './BrokerApi';
 import { ChildOrdersParam, SendChildOrderRequest, ChildOrder, BoardResponse } from './types';
-import { eRound, toExecution } from '../util';
+import { eRound, toExecution, calculateOrderSize } from '../util';
 
 export default class BrokerAdapterImpl implements BrokerAdapter {
   private readonly brokerApi: BrokerApi;
@@ -130,6 +130,18 @@ export default class BrokerAdapterImpl implements BrokerAdapter {
         throw new Error('Not implemented.');
     }
 
+    let targetSize = 0;
+    switch (order.side) {
+      case OrderSide.Buy:
+        targetSize = calculateOrderSize(order);
+        break;
+      case OrderSide.Sell:
+        targetSize = order.size;
+        break;
+      default:
+        throw new Error('Not implemented.');
+    }
+
     let timeInForce;
     switch (order.timeInForce) {
       case TimeInForce.None:
@@ -150,7 +162,7 @@ export default class BrokerAdapterImpl implements BrokerAdapter {
       product_code: productCode,
       child_order_type: childOrderType,
       side: OrderSide[order.side].toUpperCase(),
-      size: order.size,
+      size: targetSize,
       time_in_force: timeInForce
     };
   }

--- a/src/OrderImpl.ts
+++ b/src/OrderImpl.ts
@@ -46,9 +46,11 @@ export default class OrderImpl implements Order {
   }
 
   get averageFilledPrice(): number {
-    return _.isEmpty(this.executions)
+    // If executions is empty, returns 0.
+    const executedSumSize = _.sumBy(this.executions, x => x.size);
+    return executedSumSize === 0
       ? 0
-      : eRound(_.sumBy(this.executions, x => x.size * x.price) / _.sumBy(this.executions, x => x.size));
+      : eRound(_.sumBy(this.executions, x => x.size * x.price) / executedSumSize);
   }
 
   get filled(): boolean {

--- a/src/OrderImpl.ts
+++ b/src/OrderImpl.ts
@@ -55,6 +55,12 @@ export default class OrderImpl implements Order {
     return this.status === OrderStatus.Filled;
   }
 
+  get filledNotionalSize(): number {
+    return (this.commissionPaidByQuoted && this.side === OrderSide.Buy)
+      ? eRound(this.filledSize * (1 - this.commissionPercent / 100) / (1 + this.commissionPercent / 100))
+      : this.filledSize;
+  }
+
   get filledNotional(): number {
     return this.averageFilledPrice * this.filledSize;
   }

--- a/src/OrderImpl.ts
+++ b/src/OrderImpl.ts
@@ -62,7 +62,7 @@ export default class OrderImpl implements Order {
   }
 
   get filledNotional(): number {
-    return this.averageFilledPrice * this.filledSize;
+    return this.averageFilledPrice * this.filledNotionalSize;
   }
 }
 

--- a/src/OrderImpl.ts
+++ b/src/OrderImpl.ts
@@ -12,6 +12,8 @@ export interface OrderInit {
   cashMarginType: CashMarginType;
   type: OrderType;
   leverageLevel: number;
+  commissionPercent: number;
+  commissionPaidByQuoted: boolean;
 }
 
 export default class OrderImpl implements Order {
@@ -26,6 +28,8 @@ export default class OrderImpl implements Order {
   cashMarginType: CashMarginType;
   type: OrderType;
   leverageLevel: number;
+  commissionPercent: number;
+  commissionPaidByQuoted: boolean;
   id: string = uuid();
   symbol: string;
   timeInForce: TimeInForce = TimeInForce.None;

--- a/src/PairTrader.ts
+++ b/src/PairTrader.ts
@@ -101,7 +101,7 @@ export default class PairTrader extends EventEmitter {
     this.log.info(t`SendingOrderTargettingQuote`, formatQuote(quote));
     const brokerConfig = findBrokerConfig(this.configStore.config, quote.broker);
     const { config } = this.configStore;
-    const { cashMarginType, leverageLevel } = brokerConfig;
+    const { cashMarginType, leverageLevel, commissionPercent, commissionPaidByQuoted } = brokerConfig;
     const orderSide = quote.side === QuoteSide.Ask ? OrderSide.Buy : OrderSide.Sell;
     const orderPrice = 
      (quote.side === QuoteSide.Ask && config.acceptablePriceRange !== undefined)
@@ -117,7 +117,9 @@ export default class PairTrader extends EventEmitter {
       price: orderPrice,
       cashMarginType,
       type: orderType,
-      leverageLevel
+      leverageLevel,
+      commissionPercent,
+      commissionPaidByQuoted
     });
     await this.brokerAdapterRouter.send(order);
     return order;

--- a/src/SingleLegHandler.ts
+++ b/src/SingleLegHandler.ts
@@ -59,7 +59,9 @@ export default class SingleLegHandler {
       price,
       cashMarginType: largeLeg.cashMarginType,
       type: OrderType.Limit,
-      leverageLevel: largeLeg.leverageLevel
+      leverageLevel: largeLeg.leverageLevel,
+      commissionPercent: largeLeg.commissionPercent,
+      commissionPaidByQuoted: largeLeg.commissionPaidByQuoted
     });
     await this.sendOrderWithTtl(reversalOrder, options.ttl);
     return [reversalOrder];
@@ -81,7 +83,9 @@ export default class SingleLegHandler {
       price,
       cashMarginType: smallLeg.cashMarginType,
       type: OrderType.Limit,
-      leverageLevel: smallLeg.leverageLevel
+      leverageLevel: smallLeg.leverageLevel,
+      commissionPercent: smallLeg.commissionPercent,
+      commissionPaidByQuoted: smallLeg.commissionPaidByQuoted
     });
     await this.sendOrderWithTtl(proceedOrder, options.ttl);
     return [proceedOrder];

--- a/src/SingleLegHandler.ts
+++ b/src/SingleLegHandler.ts
@@ -1,5 +1,4 @@
 import { OnSingleLegConfig, ReverseOption, ProceedOption, OrderSide, OrderType, OrderPair, ConfigStore } from './types';
-import { LOT_MIN_DECIMAL_PLACE } from './constants';
 import OrderImpl from './OrderImpl';
 import * as _ from 'lodash';
 import { getLogger } from '@bitr/logger';
@@ -48,7 +47,7 @@ export default class SingleLegHandler {
     const largeLeg = orders[0].filledSize <= orders[1].filledSize ? orders[1] : orders[0];
     const sign = largeLeg.side === OrderSide.Buy ? -1 : 1;
     const price = _.round(largeLeg.price * (1 + sign * options.limitMovePercent / 100));
-    const size = _.floor(largeLeg.filledSize - smallLeg.filledSize, LOT_MIN_DECIMAL_PLACE);
+    const size = this.calculateReverseTargetSize(largeLeg, smallLeg);
     const { baseCcy } = splitSymbol(this.symbol);
     this.log.info(t`ReverseFilledLeg`, OrderUtil.toShortString(largeLeg), price.toLocaleString(), size, baseCcy);
     const reversalOrder = new OrderImpl({
@@ -72,7 +71,7 @@ export default class SingleLegHandler {
     const largeLeg = orders[0].filledSize <= orders[1].filledSize ? orders[1] : orders[0];
     const sign = smallLeg.side === OrderSide.Buy ? 1 : -1;
     const price = _.round(smallLeg.price * (1 + sign * options.limitMovePercent / 100));
-    const size = _.floor(smallLeg.pendingSize - largeLeg.pendingSize, LOT_MIN_DECIMAL_PLACE);
+    const size = this.calculateProceedTargetSize(smallLeg, largeLeg);
     const { baseCcy } = splitSymbol(this.symbol);
     this.log.info(t`ExecuteUnfilledLeg`, OrderUtil.toShortString(smallLeg), price.toLocaleString(), size, baseCcy);
     const proceedOrder = new OrderImpl({
@@ -89,6 +88,30 @@ export default class SingleLegHandler {
     });
     await this.sendOrderWithTtl(proceedOrder, options.ttl);
     return [proceedOrder];
+  }
+
+  private calculateReverseTargetSize(leftLeg: OrderImpl, rightLeg: OrderImpl): number {
+    let leftSize = leftLeg.filledSize;
+    let rightSize = rightLeg.filledSize;
+    if (leftLeg.commissionPaidByQuoted) {
+      leftSize = leftSize / (1 - leftLeg.commissionPercent / 100);
+    }
+    if (rightLeg.commissionPaidByQuoted) {
+      rightSize = rightSize / (1 - rightLeg.commissionPercent / 100);
+    }
+    return _.floor(leftSize - rightSize, 8);
+  }
+
+  private calculateProceedTargetSize(leftLeg: OrderImpl, rightLeg: OrderImpl): number {
+    let leftSize = leftLeg.pendingSize;
+    let rightSize = rightLeg.pendingSize;
+    if (leftLeg.commissionPaidByQuoted) {
+      leftSize = leftSize / (1 - leftLeg.commissionPercent / 100);
+    }
+    if (rightLeg.commissionPaidByQuoted) {
+      rightSize = rightSize / (1 - rightLeg.commissionPercent / 100);
+    }
+    return _.floor(leftSize - rightSize, 8);
   }
 
   private async sendOrderWithTtl(order: OrderImpl, ttl: number) {

--- a/src/SpreadAnalyzer.ts
+++ b/src/SpreadAnalyzer.ts
@@ -151,7 +151,14 @@ export default class SpreadAnalyzer {
   }
 
   private getBest(quotes: Quote[]) {
-    const ordered = _.orderBy(quotes, ['price']);
+    const config = this.configStore.config;
+    const ordered = _.orderBy(quotes, o => {
+      if (o.side === QuoteSide.Ask) {
+        return o.price * (1 + findBrokerConfig(config, o.broker).commissionPercent / 100);
+      } else {
+        return o.price / (1 + findBrokerConfig(config, o.broker).commissionPercent / 100);
+      }
+    });
     const ask = _(ordered)
       .filter(q => q.side === QuoteSide.Ask)
       .first();
@@ -162,7 +169,14 @@ export default class SpreadAnalyzer {
   }
 
   private getWorst(quotes: Quote[]) {
-    const ordered = _.orderBy(quotes, ['price']);
+    const config = this.configStore.config;
+    const ordered = _.orderBy(quotes, o => {
+      if (o.side === QuoteSide.Ask) {
+        return o.price * (1 + findBrokerConfig(config, o.broker).commissionPercent / 100);
+      } else {
+        return o.price / (1 + findBrokerConfig(config, o.broker).commissionPercent / 100);
+      }
+    });
     const ask = _(ordered)
       .filter(q => q.side === QuoteSide.Ask)
       .last();

--- a/src/SpreadAnalyzer.ts
+++ b/src/SpreadAnalyzer.ts
@@ -70,7 +70,11 @@ export default class SpreadAnalyzer {
 
     const invertedSpread = bid.price - ask.price;
     const availableVolume = _.floor(_.min([bid.volume, ask.volume]) as number, LOT_MIN_DECIMAL_PLACE);
-    const allowedShortSize = positionMap[bid.broker].allowedShortSize;
+    let allowedShortSize = positionMap[bid.broker].allowedShortSize;
+    const bidBrokerConfig = findBrokerConfig(this.configStore.config, bid.broker);
+    if (bidBrokerConfig.commissionPaidByQuoted) {
+      allowedShortSize = allowedShortSize / (1 + bidBrokerConfig.commissionPercent / 100);
+    }
     const allowedLongSize = positionMap[ask.broker].allowedLongSize;
     let targetVolume = _.min([availableVolume, config.maxSize, allowedShortSize, allowedLongSize]) as number;
     targetVolume = _.floor(targetVolume, LOT_MIN_DECIMAL_PLACE);

--- a/src/pnl.ts
+++ b/src/pnl.ts
@@ -10,7 +10,7 @@ export function calcCommission(price: number, volume: number, commissionPercent:
 export function calcProfit(orders: OrderImpl[], config: ConfigRoot): { profit: number; commission: number } {
   const commission = _(orders).sumBy(o => {
     const brokerConfig = findBrokerConfig(config, o.broker);
-    return calcCommission(o.averageFilledPrice, o.filledSize, brokerConfig.commissionPercent);
+    return calcCommission(o.averageFilledPrice, o.filledNotionalSize, brokerConfig.commissionPercent);
   });
   const profit = _(orders).sumBy(o => (o.side === OrderSide.Sell ? 1 : -1) * o.filledNotional) - commission;
   return { profit, commission };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -34,6 +34,8 @@ export interface Order {
   sentTime: Date;
   lastUpdated: Date;
   executions: Execution[];
+  commissionPercent: number;
+  commissionPaidByQuoted: boolean;
 }
 
 export enum OrderSide {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -12,6 +12,7 @@ export interface BrokerConfigType {
   cashMarginType: CashMarginType;
   leverageLevel: number;
   commissionPercent: number;
+  commissionPaidByQuoted: boolean;
 }
 
 export class BrokerConfig extends Castable implements BrokerConfigType {
@@ -25,6 +26,7 @@ export class BrokerConfig extends Castable implements BrokerConfigType {
   @cast cashMarginType: CashMarginType;
   @cast leverageLevel: number;
   @cast commissionPercent: number;
+  @cast commissionPaidByQuoted: boolean;
   @cast @element(Array, String) noTradePeriods: string[][];
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -104,3 +104,11 @@ export function formatQuote(quote: Quote) {
     `${padStart(quote.price.toLocaleString(), 7)} ${_.round(quote.volume, 3)}`
   );
 }
+
+export function calculateOrderSize(order: Order): number {
+  if (order.commissionPaidByQuoted) {
+    return _.floor(order.size * (1 + order.commissionPercent / 100) / (1 - order.commissionPercent / 100), 8);
+  } else {
+    return order.size;
+  }
+}


### PR DESCRIPTION
Add new configuration parameter and implementation of `commissionPaidByQuoted` for Bitflyer.

- This parameter is required for commission fee handling with quoted currency such as BTC (not JPY). It is so useful for some brokers such as Bitflyer :)