### PR TITLE
Add order use only API implementation for Bitbankcc and Coincheck.

### DIFF
--- a/src/Bitbankcc/BrokerAdapterImpl.ts
+++ b/src/Bitbankcc/BrokerAdapterImpl.ts
@@ -26,7 +26,7 @@ export default class BrokerAdapterImpl implements BrokerAdapter {
     if (this.config.orderKey && this.config.orderSecret) {
       this.brokerOrderApi = new BrokerApi(this.config.orderKey, this.config.orderSecret);
     } else {
-      this.brokerOrderApi = new BrokerApi(this.config.key, this.config.secret);
+      this.brokerOrderApi = this.brokerApi;
     }
     this.brokerApi.on('private_request', req =>
       this.log.debug(`Sending HTTP request... URL: ${req.url} Request: ${JSON.stringify(req)}`)

--- a/src/Bitbankcc/BrokerAdapterImpl.ts
+++ b/src/Bitbankcc/BrokerAdapterImpl.ts
@@ -18,14 +18,26 @@ import { eRound } from '../util';
 export default class BrokerAdapterImpl implements BrokerAdapter {
   private readonly log = getLogger('Bitbankcc.BrokerAdapter');
   private readonly brokerApi: BrokerApi;
+  private readonly brokerOrderApi: BrokerApi;
   readonly broker = 'Bitbankcc';
 
   constructor(private readonly config: BrokerConfigType) {
     this.brokerApi = new BrokerApi(this.config.key, this.config.secret);
+    if (this.config.orderKey && this.config.orderSecret) {
+      this.brokerOrderApi = new BrokerApi(this.config.orderKey, this.config.orderSecret);
+    } else {
+      this.brokerOrderApi = new BrokerApi(this.config.key, this.config.secret);
+    }
     this.brokerApi.on('private_request', req =>
       this.log.debug(`Sending HTTP request... URL: ${req.url} Request: ${JSON.stringify(req)}`)
     );
+    this.brokerOrderApi.on('private_request', req =>
+      this.log.debug(`Sending HTTP request... URL: ${req.url} Request: ${JSON.stringify(req)}`)
+    );
     this.brokerApi.on('private_response', (response, request) =>
+      this.log.debug(`Response from ${request.url}. Content: ${JSON.stringify(response)}`)
+    );
+    this.brokerOrderApi.on('private_response', (response, request) =>
       this.log.debug(`Response from ${request.url}. Content: ${JSON.stringify(response)}`)
     );
   }
@@ -35,7 +47,7 @@ export default class BrokerAdapterImpl implements BrokerAdapter {
       throw new Error();
     }
     const request = this.mapOrderToSendOrderRequest(order);
-    const reply = await this.brokerApi.sendOrder(request);
+    const reply = await this.brokerOrderApi.sendOrder(request);
     order.brokerOrderId = String(reply.order_id);
     order.status = OrderStatus.New;
     order.sentTime = new Date();
@@ -80,7 +92,7 @@ export default class BrokerAdapterImpl implements BrokerAdapter {
 
   async cancel(order: Order): Promise<void> {
     const pair = this.mapSymbolToPair(order.symbol);
-    await this.brokerApi.cancelOrder({ pair, order_id: Number(order.brokerOrderId) });
+    await this.brokerOrderApi.cancelOrder({ pair, order_id: Number(order.brokerOrderId) });
     order.lastUpdated = new Date();
     order.status = OrderStatus.Canceled;
   }

--- a/src/Coincheck/CashStrategy.ts
+++ b/src/Coincheck/CashStrategy.ts
@@ -4,7 +4,7 @@ import { CashMarginType, Order, OrderSide, OrderStatus } from '../types';
 import { calculateCoincheckOrderPrice } from './util';
 
 export default class CashStrategy implements CashMarginTypeStrategy {
-  constructor(private readonly brokerApi: BrokerApi) {}
+  constructor(private readonly brokerApi: BrokerApi, private readonly brokerOrderApi: BrokerApi) {}
 
   async send(order: Order): Promise<void> {
     if (order.cashMarginType !== CashMarginType.Cash) {
@@ -16,7 +16,7 @@ export default class CashStrategy implements CashMarginTypeStrategy {
       amount: order.size,
       rate: calculateCoincheckOrderPrice(order)
     };
-    const reply = await this.brokerApi.newOrder(request);
+    const reply = await this.brokerOrderApi.newOrder(request);
     if (!reply.success) {
       throw new Error('Send failed.');
     }

--- a/src/Coincheck/MarginOpenStrategy.ts
+++ b/src/Coincheck/MarginOpenStrategy.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import { calculateCoincheckOrderPrice } from './util';
 
 export default class MarginOpenStrategy implements CashMarginTypeStrategy {
-  constructor(private readonly brokerApi: BrokerApi) {}
+  constructor(private readonly brokerApi: BrokerApi, private readonly brokerOrderApi: BrokerApi) {}
 
   async send(order: Order): Promise<void> {
     if (order.cashMarginType !== CashMarginType.MarginOpen) {
@@ -18,7 +18,7 @@ export default class MarginOpenStrategy implements CashMarginTypeStrategy {
       amount: order.size,
       rate: calculateCoincheckOrderPrice(order)
     };
-    const reply = await this.brokerApi.newOrder(request);
+    const reply = await this.brokerOrderApi.newOrder(request);
     if (!reply.success) {
       throw new Error('Send failed.');
     }

--- a/src/Coincheck/NetOutStrategy.ts
+++ b/src/Coincheck/NetOutStrategy.ts
@@ -6,14 +6,14 @@ import * as _ from 'lodash';
 import { calculateCoincheckOrderPrice } from './util';
 
 export default class NetOutStrategy implements CashMarginTypeStrategy {
-  constructor(private readonly brokerApi: BrokerApi) {}
+  constructor(private readonly brokerApi: BrokerApi, private readonly brokerOrderApi: BrokerApi) {}
 
   async send(order: Order): Promise<void> {
     if (order.cashMarginType !== CashMarginType.NetOut) {
       throw new Error();
     }
     const request = await this.getNetOutRequest(order);
-    const reply = await this.brokerApi.newOrder(request);
+    const reply = await this.brokerOrderApi.newOrder(request);
     if (!reply.success) {
       throw new Error('Send failed.');
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -8,6 +8,8 @@ export interface BrokerConfigType {
   enabled: boolean;
   key: string;
   secret: string;
+  orderKey?: string;
+  orderSecret?: string;
   maxLongPosition: number;
   maxShortPosition: number;
   cashMarginType: CashMarginType;
@@ -22,6 +24,8 @@ export class BrokerConfig extends Castable implements BrokerConfigType {
   @cast enabled: boolean;
   @cast key: string;
   @cast secret: string;
+  @cast orderKey?: string;
+  @cast orderSecret?: string;
   @cast maxLongPosition: number;
   @cast maxShortPosition: number;
   @cast cashMarginType: CashMarginType;


### PR DESCRIPTION
Add order use only API implementation for Bitbankcc and Coincheck.

- For Bitbankcc and Coincheck, these APIs are in severe condition under nonce handling between actual order and position refresh tasks (For example: Coincheck APIs do not accept requests when the second or later API calls are within 30 ms)
  To avoid this, it is nice to prepare two API object which has different API keys 🐱
  In this PR, I introduced `orderKey` and `orderSecret` new configuration to handle it and improve broker logics.